### PR TITLE
Cross Dimension Distance Fix + Inventory Has Function

### DIFF
--- a/BitCraftServer/packages/game/src/game/coordinates/consts.rs
+++ b/BitCraftServer/packages/game/src/game/coordinates/consts.rs
@@ -18,3 +18,9 @@ pub const HASH_GRID_SCALE: f32 = 0.25;
 
 pub const FLOAT_COORD_PRECISION: u32 = 3;
 pub const FLOAT_COORD_PRECISION_MUL: i32 = 10i32.pow(FLOAT_COORD_PRECISION);
+
+// Returned when comparing coordinates across DIFFERENT dimensions.
+// Represents an unreachable distance rather than a real geometric value.
+// Use MAX / 10 instead of MAX to avoid integer overflows.
+pub const UNREACHABLE_DISTANCE_I32: i32 = i32::MAX / 10;
+pub const UNREACHABLE_DISTANCE_F32: f32 = f32::INFINITY;

--- a/BitCraftServer/packages/game/src/game/coordinates/float_hex_tile.rs
+++ b/BitCraftServer/packages/game/src/game/coordinates/float_hex_tile.rs
@@ -75,9 +75,17 @@ impl FloatHexTile {
         -self.x - self.z
     }
 
-    pub fn distance_to(&self, other: FloatHexTile) -> f32 {
-        return (((other.x - self.x).abs() + (other.y() - self.y()).abs() + (other.z - self.z).abs()) / 2) as f32
-            / FLOAT_COORD_PRECISION_MUL as f32;
+    pub fn distance_to(&self, other: &FloatHexTile) -> f32 {
+    // Positions in different dimensions should never interact.
+    // Return UNREACHABLE_DISTANCE so any distance checks (distance < range) safely fail
+    if self.dimension != other.dimension {
+        return UNREACHABLE_DISTANCE_F32;
+    }
+
+    return ((((other.x - self.x).abs()
+        + (other.y() - self.y()).abs()
+        + (other.z - self.z).abs()) / 2) as f32)
+        / FLOAT_COORD_PRECISION_MUL as f32;
     }
 
     pub fn to_world_position(&self) -> Vector2 {

--- a/BitCraftServer/packages/game/src/game/coordinates/hex_coordinates.rs
+++ b/BitCraftServer/packages/game/src/game/coordinates/hex_coordinates.rs
@@ -185,8 +185,16 @@ impl HexCoordinates {
     }
 
     pub fn distance_to(&self, other: HexCoordinates) -> i32 {
-        return ((other.x - self.x).abs() + (other.y() - self.y()).abs() + (other.z - self.z).abs()) / 2;
+    // Positions in different dimensions should never interact.
+    // Return UNREACHABLE_DISTANCE so any distance checks (distance < range) safely fail
+    if self.dimension != other.dimension {
+        return UNREACHABLE_DISTANCE_I32;
     }
+
+    return ((other.x - self.x).abs()
+        + (other.y() - self.y()).abs()
+        + (other.z - self.z).abs()) / 2;
+}
 
     pub fn get_terrain_coordinates(&self) -> [HexCoordinates; 3] {
         // There technically are two types of corner cells based

--- a/BitCraftServer/packages/game/src/game/entities/inventory_state.rs
+++ b/BitCraftServer/packages/game/src/game/entities/inventory_state.rs
@@ -403,17 +403,21 @@ impl InventoryState {
     }
 
     pub fn has(&self, item_stacks: &Vec<ItemStack>) -> bool {
-        if item_stacks.len() == 0 {
+        if item_stacks.is_empty() {
             return true;
         }
 
         let merged_stacks = ItemStack::merge_multiple(item_stacks);
+
         for stack in merged_stacks {
             let mut required = stack.quantity;
+
             for p in self.pockets.iter() {
                 required -= match &p.contents {
                     Some(c) => {
-                        if c.item_id == stack.item_id {
+                        // Need to check both item ID and type to ensure we're matching the correct item/cargo
+                        // If durability is ever re-added as a game mechanic, should also be considered here
+                        if c.item_id == stack.item_id && c.item_type == stack.item_type {
                             c.quantity
                         } else {
                             0


### PR DESCRIPTION
## Summary
Fixes cross-dimension distance handling and corrects `InventoryState::has()` validation.

## Changes
- Distance functions now return an unreachable sentinel when dimensions differ to prevent unintended interactions.
- `InventoryState::has()` now validates using both `item_id` and `item_type` instead of only `item_id`. This prevents items and cargos that share the same id from being counted interchangeably.
- Minor idiomatic cleanup (`is_empty()` replaces `len() == 0`, no behavioral change - but avoids linter complaint).