### PR TITLE
validate source inventory type on drop

### DIFF
--- a/BitCraftServer/packages/game/src/game/handlers/inventory/inventory_helper.rs
+++ b/BitCraftServer/packages/game/src/game/handlers/inventory/inventory_helper.rs
@@ -164,3 +164,10 @@ pub fn validate_swap(source_inventory_type: &InventoryType, target_inventory_typ
 
     return Ok(());
 }
+
+pub fn validate_drop(source_inventory_type: &InventoryType) -> Result<(), String> {
+    if *source_inventory_type == InventoryType::Dropped {
+        return Err("Cannot drop items from a dropped inventory".into());
+    }
+    return Ok(());
+}

--- a/BitCraftServer/packages/game/src/game/handlers/inventory/item_drop.rs
+++ b/BitCraftServer/packages/game/src/game/handlers/inventory/item_drop.rs
@@ -43,13 +43,16 @@ pub fn item_drop(ctx: &ReducerContext, request: PlayerItemDropRequest) -> Result
             ctx.db.inventory_state().entity_id().find(&request.pocket.inventory_entity_id),
             "Invalid source inventory"
         );
-        inventory_helper::validate_interact(
+        let source_inventory_type = inventory_helper::validate_interact(
             ctx,
             actor_id,
             pile_coordinates,
             source_inventory.owner_entity_id,
             source_inventory.player_owner_entity_id,
         )?;
+
+        // Ensure this inventory type is allowed as a drop source.
+        inventory_helper::validate_drop(&source_inventory_type)?;
 
         let pocket_index: usize = request.pocket.pocket_index as usize;
         item_stack = unwrap_or_err!(


### PR DESCRIPTION
### Summary
Prevents dropping items from inventories that are already of type `Dropped`.

### Changes
- Added `inventory_helper::validate_drop()` to validate drop source inventory type.
- Called the validation in `item_drop` after `validate_interact`.
- Future inventory types that are not allowed to be dropped from can be added to `validate_drop`