### PR TITLE
hex loss from barter stall

### DIFF
--- a/BitCraftServer/packages/game/src/game/handlers/player_trade/barter_stall_order_accept.rs
+++ b/BitCraftServer/packages/game/src/game/handlers/player_trade/barter_stall_order_accept.rs
@@ -276,7 +276,8 @@ pub fn reduce(ctx: &ReducerContext, entity_id: u64, shop_entity_id: u64, trade_o
                             let _ = item_inventory.remove(&coin_item);
                         } else {
                             // pay partly from the treasury
-                            removed_from_treasury = (coin_item[0].quantity - barter_coins) as u32;
+                            // Use removed_coins directly for clarity; coin_item[0].quantity is the same value here.
+                            removed_from_treasury = (removed_coins - barter_coins) as u32;
                             // and partly from the storage
                             coin_item[0].quantity = barter_coins;
                             let _ = item_inventory.remove(&coin_item);
@@ -287,11 +288,13 @@ pub fn reduce(ctx: &ReducerContext, entity_id: u64, shop_entity_id: u64, trade_o
 
                     if removed_from_treasury > 0 {
                         let mut claim_local = claim.as_ref().unwrap().local_state(ctx);
-                        if claim_local.treasury < removed_coins as u32 {
+                        // Only check the portion that must come from the treasury.
+                        // Some coins may have already been removed from the stall inventory.
+                        if claim_local.treasury < removed_from_treasury {
                             return Err("Vendor does not have enough funds for this transaction".into());
                         }
-                        // pay from the treasury
-                        claim_local.treasury -= removed_coins as u32;
+                        // pay only the shortfall from the treasury
+                        claim_local.treasury -= removed_from_treasury;
                         ctx.db.claim_local_state().entity_id().update(claim_local);
                     }
                 }


### PR DESCRIPTION
## Summary

Fix an issue where barter stall transactions could incorrectly deduct too many coins from the claim treasury when both the stall inventory and treasury contained coins.

Previously, the code calculated how many coins should come from the treasury (`removed_from_treasury`), but the validation and deduction logic mistakenly used the full payout amount (`removed_coins`). This caused the treasury to be charged for the entire payout instead of only the shortfall after stall inventory coins were used.

## Changes

- Ensures the treasury **only** covers the portion of the payout not available in the stall inventory.
- Clarified the calculation of `removed_from_treasury` by using `removed_coins` directly instead of `coin_item[0].quantity`.
-  `claim_local.treasury < removed_from_treasury` checks that the treasury has the amount needed after stall reduction, rather than  `claim_local.treasury < removed_coins` which checks against the full payout value


## Bug Replication

- Barter stall offers 100 coins
- Stall inventory contains 60 coins
- Claim treasury contains 200 coins

Expected:

- Player receives 100 coins
- Stall inventory provides 60 coins
- Treasury provides **40 coins**

Actual:

- Player receives 100 coins
- Stall inventory provides 60 coins
- Treasury provides **100 coins**
- 60 coins are permanently lost